### PR TITLE
replace loop with array_shift in UpdateResult::getUpsertedId()

### DIFF
--- a/src/Write/Result/UpdateResult.php
+++ b/src/Write/Result/UpdateResult.php
@@ -5,6 +5,7 @@ namespace Tequila\MongoDB\Write\Result;
 class UpdateResult
 {
     use WriteResultDecoratorTrait;
+
     /**
      * @return int
      */
@@ -34,10 +35,8 @@ class UpdateResult
      */
     public function getUpsertedId()
     {
-        foreach ($this->writeResult->getUpsertedIds() as $id) {
-            return $id;
-        }
+        $upsertedIds = $this->writeResult->getUpsertedIds();
 
-        return null;
+        return array_shift($upsertedIds);
     }
 }


### PR DESCRIPTION
The for loop here is used to fetch and immediately return the first array element. This can be safely replaced with [array_shift](http://php.net/manual/en/function.array-shift.php) call since it provides more declarative approach to gain the same result.